### PR TITLE
Two minor fixes (lazily not checked out the right branch!)

### DIFF
--- a/src/assets/stylesheets/card.scss
+++ b/src/assets/stylesheets/card.scss
@@ -11,6 +11,9 @@
   h2 {
     text-align: center;
     border-bottom: 1px solid;
+	border-left: 0px solid;
+    border-right: 0px solid;
+    border-top: 0px solid;
     border-image-slice: 1;
     padding-bottom: 0.83em;
     margin-block-end: 0;

--- a/src/layout/views/home.js
+++ b/src/layout/views/home.js
@@ -44,7 +44,7 @@ function Home() {
         <Timeline />
       </section>
       {/* timeline container */}
-      <InView threshold="0.5">
+      <InView threshold="0.5" triggerOnce>
         {({ inView, ref }) => (
           <div ref={ref}>
             <Pies inview={inView} />


### PR DESCRIPTION
Trigger pie chart animation only once
Remove weird border artifacting on Safari (was fine on every other device/browser, but Safari required explicitly declaring `border-*: 0px solid`